### PR TITLE
replace text with icons

### DIFF
--- a/djangocms_history/cms_toolbars.py
+++ b/djangocms_history/cms_toolbars.py
@@ -40,6 +40,8 @@ class AjaxButton(BaseButton):
 
 @toolbar_pool.register
 class UndoRedoToolbar(CMSToolbar):
+    undo_image = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABOklEQVR4Ae3WNVZDQRhAYdyhimcBeMsG6CI1C8Dd9pK0rACXCm+QDoeaFnfnFlNNns4bnHvO10T/55Plsv/+i6ITMzjCtXCAOfFeBJ5axCb80h+n8YA3G49IIwSl3oRtBBDHKd5cukBSeQDhGC94U/SCXvUBjO2gF9UoFWoxiF2TIZI6BrhHF3JgVq4Y7sHgcIS8DnCEAJzUaDBESsch2IYfTuo1uDoiOs6BdTgp1+Cc6IBtqzYDLMBpg9J3p/Gp1UoDHOBTK5MGuMKnViFfjn/uEAx95UmofBnKFaAKbuszuBGFVf58Ag9IgLzfip2WjzHpYTSIXIWH0TmCcFUDXk0ex8OoRwXKUIchi8dxAkq1fMWCRK5JcUl2jgS0FMAInh0uSlPyMdc5SBdmsItLXGEfM+hwe6n99987pVTygpWk5ykAAAAASUVORK5CYII='
+    redo_image = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABP0lEQVR42u3WP0vDQBiAcSXoYMWtpcYPoFjd3R01rn4Alx40Q9vv0q5+AxGsbiKOuoharM7OQv8MVqzng3Q6Ei5vLmQxD/zGcC9ckruFoiJhPhSuMMBk7g0XUNhA5q2jiy9oiyk6xiBl3OMG4gKMoIU+cIAKnqABWSFm0CnN8A4NQNBRzOJ9NFFDCSvYRB0PtqEkez6M2NsGPMS1CIVP1wG6EYvvI0llDFwG8CPe9oZg8UfXLVARe+4hSXdZvAOXxgNNJO3asvgtrL0aD20j18bGAKv/bgBzC2rILflLKM/9M3RP/iMKIW0Ly7Am/xXbCzDFedohqjGHUWjZDg8t4zA6wxLEBYg7jlvYQQlr2EUbz9CGH+xhXv4XkhM4dYhhyivZMTKpKriUfuMUFWSejzp6eMEYI/TRg/pbuKhI0C8BZPKBEtpCEgAAAABJRU5ErkJggg=='
 
     def populate(self):
         self.active_operation = self.get_active_operation()
@@ -90,12 +92,28 @@ class UndoRedoToolbar(CMSToolbar):
     def get_undo_button(self):
         url = reverse('admin:djangocms_history_undo')
         disabled = not bool(self.active_operation)
-        # TODO: Replace with icon to save space
-        return self._get_ajax_button(ugettext('Undo'), url, disabled=disabled)
+        return self._get_ajax_button(
+            """
+            <span>
+                <img
+                    aria-hidden="true" style="vertical-align: text-bottom"
+                    width="16" height="16" src="{url}" alt="{title}"
+                    title="{title}">
+                <span class="cms-hidden" style="display: none;">{title}</span>
+            </span>
+            """.format(url=self.undo_image, title=ugettext('Undo')), url, disabled=disabled)
 
     def get_redo_button(self):
         operation = self.get_inactive_operation()
         url = reverse('admin:djangocms_history_redo')
         disabled = not bool(operation)
-        # TODO: Replace with icon to save space
-        return self._get_ajax_button(ugettext('Redo'), url, disabled=disabled)
+        return self._get_ajax_button(
+            """
+            <span>
+                <img
+                    aria-hidden="true" style="vertical-align: text-bottom"
+                    width="16" height="16" src="{url}" alt="{title}"
+                    title="{title}">
+                <span class="cms-hidden" style="display: none;">{title}</span>
+            </span>
+            """.format(url=self.redo_image, title=ugettext('Redo')), url, disabled=disabled)

--- a/djangocms_history/cms_toolbars.py
+++ b/djangocms_history/cms_toolbars.py
@@ -9,6 +9,8 @@ from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.toolbar.items import BaseButton, ButtonList
 
+from sekizai.helpers import get_varname
+
 from .helpers import (
     get_active_operation,
     get_inactive_operation,
@@ -19,17 +21,19 @@ from .helpers import (
 class AjaxButton(BaseButton):
     template = 'djangocms_history/toolbar/ajax_button.html'
 
-    def __init__(self, name, url, data, active=False, disabled=False):
+    def __init__(self, name, url, data, icon, active=False, disabled=False):
         self.name = name
         self.url = url
         self.active = active
         self.disabled = disabled
         self.data = data
         self.on_success = REFRESH_PAGE
+        self.icon = icon
 
     def get_context(self):
         return {
             'name': self.name,
+            'icon': self.icon,
             'active': self.active,
             'disabled': self.disabled,
             'data': json.dumps(self.data),
@@ -40,8 +44,25 @@ class AjaxButton(BaseButton):
 
 @toolbar_pool.register
 class UndoRedoToolbar(CMSToolbar):
-    undo_image = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABOklEQVR4Ae3WNVZDQRhAYdyhimcBeMsG6CI1C8Dd9pK0rACXCm+QDoeaFnfnFlNNns4bnHvO10T/55Plsv/+i6ITMzjCtXCAOfFeBJ5axCb80h+n8YA3G49IIwSl3oRtBBDHKd5cukBSeQDhGC94U/SCXvUBjO2gF9UoFWoxiF2TIZI6BrhHF3JgVq4Y7sHgcIS8DnCEAJzUaDBESsch2IYfTuo1uDoiOs6BdTgp1+Cc6IBtqzYDLMBpg9J3p/Gp1UoDHOBTK5MGuMKnViFfjn/uEAx95UmofBnKFaAKbuszuBGFVf58Ag9IgLzfip2WjzHpYTSIXIWH0TmCcFUDXk0ex8OoRwXKUIchi8dxAkq1fMWCRK5JcUl2jgS0FMAInh0uSlPyMdc5SBdmsItLXGEfM+hwe6n99987pVTygpWk5ykAAAAASUVORK5CYII='
-    redo_image = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABP0lEQVR42u3WP0vDQBiAcSXoYMWtpcYPoFjd3R01rn4Alx40Q9vv0q5+AxGsbiKOuoharM7OQv8MVqzng3Q6Ei5vLmQxD/zGcC9ckruFoiJhPhSuMMBk7g0XUNhA5q2jiy9oiyk6xiBl3OMG4gKMoIU+cIAKnqABWSFm0CnN8A4NQNBRzOJ9NFFDCSvYRB0PtqEkez6M2NsGPMS1CIVP1wG6EYvvI0llDFwG8CPe9oZg8UfXLVARe+4hSXdZvAOXxgNNJO3asvgtrL0aD20j18bGAKv/bgBzC2rILflLKM/9M3RP/iMKIW0Ly7Am/xXbCzDFedohqjGHUWjZDg8t4zA6wxLEBYg7jlvYQQlr2EUbz9CGH+xhXv4XkhM4dYhhyivZMTKpKriUfuMUFWSejzp6eMEYI/TRg/pbuKhI0C8BZPKBEtpCEgAAAABJRU5ErkJggg=='
+    undo_icon = (
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABOklEQVR4A'
+        'e3WNVZDQRhAYdyhimcBeMsG6CI1C8Dd9pK0rACXCm+QDoeaFnfnFlNNns4bnHvO10T/55Plsv/+i6ITM'
+        'zjCtXCAOfFeBJ5axCb80h+n8YA3G49IIwSl3oRtBBDHKd5cukBSeQDhGC94U/SCXvUBjO2gF9UoFWoxi'
+        'F2TIZI6BrhHF3JgVq4Y7sHgcIS8DnCEAJzUaDBESsch2IYfTuo1uDoiOs6BdTgp1+Cc6IBtqzYDLMBpg9J3p'
+        '/Gp1UoDHOBTK5MGuMKnViFfjn/uEAx95UmofBnKFaAKbuszuBGFVf58Ag9IgLzfip2WjzHpYTSIXIWH0TmCcF'
+        'UDXk0ex8OoRwXKUIchi8dxAkq1fMWCRK5JcUl2jgS0FMAInh0uSlPyMdc5SBdmsItLXGEfM+hwe6n99987pVTyg'
+        'pWk5ykAAAAASUVORK5CYII='
+    )
+    redo_icon = (
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABP0lEQVR42u'
+        '3WP0vDQBiAcSXoYMWtpcYPoFjd3R01rn4Alx40Q9vv0q5+AxGsbiKOuoharM7OQv8MVqzng3Q6Ei5vLmQ'
+        'xD/zGcC9ckruFoiJhPhSuMMBk7g0XUNhA5q2jiy9oiyk6xiBl3OMG4gKMoIU+cIAKnqABWSFm0CnN8A4NQ'
+        'NBRzOJ9NFFDCSvYRB0PtqEkez6M2NsGPMS1CIVP1wG6EYvvI0llDFwG8CPe9oZg8UfXLVARe+4hSXdZvAOX'
+        'xgNNJO3asvgtrL0aD20j18bGAKv/bgBzC2rILflLKM/9M3RP/iMKIW0Ly7Am/xXbCzDFedohqjGHUWjZDg8t'
+        '4zA6wxLEBYg7jlvYQQlr2EUbz9CGH+xhXv4XkhM4dYhhyivZMTKpKriUfuMUFWSejzp6eMEYI/TRg/pbuKhI0'
+        'C8BZPKBEtpCEgAAAABJRU5ErkJggg=='
+    )
+    icon_css = '<style>.cms-btn-disabled img {opacity: 0.2;}</style>'
 
     def populate(self):
         self.active_operation = self.get_active_operation()
@@ -74,16 +95,17 @@ class UndoRedoToolbar(CMSToolbar):
         container.buttons.append(self.get_redo_button())
         self.toolbar.add_item(container)
 
-    def _get_ajax_button(self, name, url, disabled=True):
+    def _get_ajax_button(self, name, url, icon, disabled=True):
         data = {
             'language': self.toolbar.language,
             'cms_path': self.request.path,
             'csrfmiddlewaretoken': self.toolbar.csrf_token,
         }
         button = AjaxButton(
-            name,
-            url,
+            name=name,
+            url=url,
             data=data,
+            icon=icon,
             active=False,
             disabled=disabled,
         )
@@ -92,28 +114,29 @@ class UndoRedoToolbar(CMSToolbar):
     def get_undo_button(self):
         url = reverse('admin:djangocms_history_undo')
         disabled = not bool(self.active_operation)
-        return self._get_ajax_button(
-            """
-            <span>
-                <img
-                    aria-hidden="true" style="vertical-align: text-bottom"
-                    width="16" height="16" src="{url}" alt="{title}"
-                    title="{title}">
-                <span class="cms-hidden" style="display: none;">{title}</span>
-            </span>
-            """.format(url=self.undo_image, title=ugettext('Undo')), url, disabled=disabled)
+        button = self._get_ajax_button(
+            name=ugettext('Undo'),
+            url=url,
+            icon=self.undo_icon,
+            disabled=disabled,
+        )
+        return button
 
     def get_redo_button(self):
         operation = self.get_inactive_operation()
         url = reverse('admin:djangocms_history_redo')
         disabled = not bool(operation)
-        return self._get_ajax_button(
-            """
-            <span>
-                <img
-                    aria-hidden="true" style="vertical-align: text-bottom"
-                    width="16" height="16" src="{url}" alt="{title}"
-                    title="{title}">
-                <span class="cms-hidden" style="display: none;">{title}</span>
-            </span>
-            """.format(url=self.redo_image, title=ugettext('Redo')), url, disabled=disabled)
+        button = self._get_ajax_button(
+            name=ugettext('Redo'),
+            url=url,
+            icon=self.redo_icon,
+            disabled=disabled,
+        )
+        return button
+
+    def render_addons(self, context):
+        # TODO: This is a workaround to add our css to sekizai
+        # Should be fixed on the cms core by exposing the context
+        # to the toolbar populate methods.
+        context[get_varname()]['css'].append(self.icon_css)
+        return []

--- a/djangocms_history/templates/djangocms_history/toolbar/ajax_button.html
+++ b/djangocms_history/templates/djangocms_history/toolbar/ajax_button.html
@@ -1,6 +1,9 @@
-<style>
-    .cms-btn-disabled img {
-        opacity: 0.2;
-    }
-</style>
-<a href="{{ url }}" data-rel="ajax" data-post="{{ data }}" class="cms-btn{% if active %} cms-btn-active{% endif %}{% if disabled %} cms-btn-disabled{% endif %}" data-on-success="{{ on_success }}">{{ name|safe }}</a>
+<a href="{{ url }}" data-rel="ajax" data-post="{{ data }}" class="cms-btn{% if active %} cms-btn-active{% endif %}{% if disabled %} cms-btn-disabled{% endif %}" data-on-success="{{ on_success }}">
+    <span>
+        <img
+            aria-hidden="true" style="vertical-align: text-bottom"
+            width="16" height="16" src="{{ icon }}" alt="{{ name }}"
+            title="{{ name }}">
+        <span class="cms-hidden" style="display: none;">{{ name }}</span>
+    </span>
+</a>

--- a/djangocms_history/templates/djangocms_history/toolbar/ajax_button.html
+++ b/djangocms_history/templates/djangocms_history/toolbar/ajax_button.html
@@ -1,1 +1,6 @@
-<a href="{{ url }}" data-rel="ajax" data-post="{{ data }}" class="cms-btn{% if active %} cms-btn-active{% endif %}{% if disabled %} cms-btn-disabled{% endif %}" data-on-success="{{ on_success }}">{{ name }}</a>
+<style>
+    .cms-btn-disabled img {
+        opacity: 0.2;
+    }
+</style>
+<a href="{{ url }}" data-rel="ajax" data-post="{{ data }}" class="cms-btn{% if active %} cms-btn-active{% endif %}{% if disabled %} cms-btn-disabled{% endif %}" data-on-success="{{ on_success }}">{{ name|safe }}</a>

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import djangocms_history
 INSTALL_REQUIREMENTS = [
     'Django>=1.8,<1.11',
     'django-cms>=3.4.2',
+    'django-sekizai>=0.7',
 ]
 
 


### PR DESCRIPTION
there are some minor problems with this - the inline "style" tag that blocks rendering for a little (twice, because sekizai isn't respected there)

it can be eventually pulled into cms core, but for the moment has to be like this. there are also minor problems on very narrow screens (it could look way better)

result:

![screen shot 2017-01-15 at 10 34 49](https://cloud.githubusercontent.com/assets/366813/21961605/47c706be-db0e-11e6-9887-4b2b9f21f2c8.png)

icons taken from fontawesome