### PR TITLE
Add compatibility for djangocms-cascade

### DIFF
--- a/djangocms_history/models.py
+++ b/djangocms_history/models.py
@@ -400,7 +400,7 @@ class PlaceholderAction(models.Model):
         unique_together = ('operation', 'order')
 
     def _object_version_data_hook(self, data):
-        if data and 'pk' in data:
+        if data and 'pk' in data and 'model' not in data:
             return ArchivedPlugin(**data)
         return data
 


### PR DESCRIPTION
### Summary

Fixes #
djangocms-cascade  don't work with djangocms-history.

### Links to related discussion
https://github.com/jrief/djangocms-cascade/issues/234


### Proposed changes in this pull request
I propose to filter the ArchivedPlugin function when it encounters a model key. I think that should not alter the way things work.