### PR TITLE
Hide placeholder operations from admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.0.1 (unreleased)
+==================
+
+* Make sure placeholder operations are not shown in the admin
+
+
 1.0.0 (2018-12-17)
 ==================
 

--- a/djangocms_history/admin.py
+++ b/djangocms_history/admin.py
@@ -8,6 +8,9 @@ from .models import PlaceholderOperation
 @admin.register(PlaceholderOperation)
 class PlaceholderOperationAdmin(admin.ModelAdmin):
 
+    def get_model_perms(self, request):
+        return {}
+
     def has_add_permission(self, request):
         return False
 


### PR DESCRIPTION
in Django 2.x and above

![image](https://user-images.githubusercontent.com/270307/50145844-c1c72980-02b2-11e9-86e3-323a4889cb82.png)
